### PR TITLE
Fix: serialize round inviteNonce (BigInt) for GraphQL String field

### DIFF
--- a/ui/server/graphql/resolvers/mutations/round.ts
+++ b/ui/server/graphql/resolvers/mutations/round.ts
@@ -236,7 +236,10 @@ export const createInvitationLink = async (
     data: { inviteNonce },
   });
   return {
-    link: round.inviteNonce,
+    // inviteNonce is a BigInt (Collection.inviteNonce is BIGINT). The GraphQL
+    // `InvitationLink.link` field is a String and cannot serialize a bigint
+    // ("String cannot represent value: <n>"), so stringify it before returning.
+    link: round.inviteNonce == null ? null : String(round.inviteNonce),
   };
 };
 


### PR DESCRIPTION
After Round.inviteNonce was changed Int -> BigInt to match the BIGINT Collection column, Prisma returns the value as a JS bigint. The invite mutation returned it directly into InvitationLink.link (a GraphQL String), which graphql-js cannot serialize ("String cannot represent value: <n>"), breaking round invite link creation with INTERNAL_SERVER_ERROR.

Stringify the nonce before returning (preserves the pre-BigInt wire value). The read/query path already converts via Number(); this was the missed write/return path.

Note: the Group/Organization invite path has a related but distinct, pre-existing bug (column still INTEGER -> Date.now() overflows on write); not fixed here as Give it a Go does not use group invites. See context repo.