### PR TITLE
feat: add priorityArea, sourceFunding, keyFundCommentary fields to Bucket

### DIFF
--- a/ui/components/Bucket/ExtraFields.tsx
+++ b/ui/components/Bucket/ExtraFields.tsx
@@ -1,0 +1,275 @@
+import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { gql, useMutation } from "urql";
+import Tooltip from "@tippyjs/react";
+
+import Button from "components/Button";
+import IconButton from "components/IconButton";
+import { EditIcon } from "components/Icons";
+
+const DEFAULT_PRIORITY_AREA_OPTIONS = [
+  "arts_culture",
+  "built_environment",
+  "green_economy",
+  "connected_to_nature",
+  "secure_homes_lives",
+  "community",
+  "education_opportunities",
+  "thriving_town_centre",
+  "other",
+];
+
+const DEFAULT_SOURCE_FUNDING_OPTIONS = [
+  "own_funds",
+  "grant",
+  "social_investment",
+  "donations",
+  "crowdfunding",
+  "other",
+];
+
+const PRIORITY_AREA_LABELS: Record<string, string> = {
+  arts_culture: "Arts and Culture",
+  built_environment: "Beautiful Built Environment",
+  green_economy: "Green Economy",
+  connected_to_nature: "Connected to Nature",
+  secure_homes_lives: "Secure Homes & Lives",
+  community: "Community",
+  education_opportunities: "Education & Opportunities",
+  thriving_town_centre: "Thriving Town Centre",
+  other: "Other",
+};
+
+const SOURCE_FUNDING_LABELS: Record<string, string> = {
+  own_funds: "Own funds",
+  grant: "Grant",
+  social_investment: "Social investment",
+  donations: "Donations",
+  crowdfunding: "Crowdfunding",
+  other: "Other",
+};
+
+const EDIT_PRIORITY_AREA = gql`
+  mutation EditBucketPriorityArea($bucketId: ID!, $priorityArea: String) {
+    editBucket(bucketId: $bucketId, priorityArea: $priorityArea) {
+      id
+      priorityArea
+    }
+  }
+`;
+
+const EDIT_SOURCE_FUNDING = gql`
+  mutation EditBucketSourceFunding($bucketId: ID!, $sourceFunding: String) {
+    editBucket(bucketId: $bucketId, sourceFunding: $sourceFunding) {
+      id
+      sourceFunding
+    }
+  }
+`;
+
+function parseOptions(envVar: string | undefined, defaults: string[]): string[] {
+  if (!envVar) return defaults;
+  return envVar.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+const BucketExtraFields = ({
+  bucket,
+  canEdit,
+}: {
+  bucket: any;
+  canEdit: boolean;
+}) => {
+  const intl = useIntl();
+
+  const [editingPriorityArea, setEditingPriorityArea] = useState(false);
+  const [editingSourceFunding, setEditingSourceFunding] = useState(false);
+
+  const [priorityAreaValue, setPriorityAreaValue] = useState(
+    bucket.priorityArea ?? ""
+  );
+  const [sourceFundingValue, setSourceFundingValue] = useState(
+    bucket.sourceFunding ?? ""
+  );
+
+  const [{ fetching: savingPriorityArea }, savePriorityArea] =
+    useMutation(EDIT_PRIORITY_AREA);
+  const [{ fetching: savingSourceFunding }, saveSourceFunding] =
+    useMutation(EDIT_SOURCE_FUNDING);
+
+  const priorityAreaOptions = parseOptions(
+    process.env.NEXT_PUBLIC_BUCKET_PRIORITY_AREA_OPTIONS,
+    DEFAULT_PRIORITY_AREA_OPTIONS
+  );
+  const sourceFundingOptions = parseOptions(
+    process.env.NEXT_PUBLIC_BUCKET_SOURCE_FUNDING_OPTIONS,
+    DEFAULT_SOURCE_FUNDING_OPTIONS
+  );
+
+  const showPriorityArea = bucket.priorityArea || canEdit;
+  const showSourceFunding = bucket.sourceFunding || canEdit;
+
+  if (!showPriorityArea && !showSourceFunding) return null;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-2 mb-4">
+      {showPriorityArea && (
+        <div>
+          <div className="text-sm font-medium text-gray-500 mb-1">
+            <FormattedMessage defaultMessage="Priority area" />
+          </div>
+          {editingPriorityArea ? (
+            <div>
+              <select
+                className="border rounded px-2 py-1 text-sm w-full mb-2"
+                value={priorityAreaValue}
+                onChange={(e) => setPriorityAreaValue(e.target.value)}
+                autoFocus
+              >
+                <option value="">—</option>
+                {priorityAreaOptions.map((key) => (
+                  <option key={key} value={key}>
+                    {PRIORITY_AREA_LABELS[key] ?? key}
+                  </option>
+                ))}
+              </select>
+              <div className="flex gap-2">
+                <Button
+                  size="small"
+                  loading={savingPriorityArea}
+                  onClick={() =>
+                    savePriorityArea({
+                      bucketId: bucket.id,
+                      priorityArea: priorityAreaValue || null,
+                    }).then(({ error }) => {
+                      if (error) alert(error.message);
+                      else setEditingPriorityArea(false);
+                    })
+                  }
+                >
+                  <FormattedMessage defaultMessage="Save" />
+                </Button>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() => {
+                    setPriorityAreaValue(bucket.priorityArea ?? "");
+                    setEditingPriorityArea(false);
+                  }}
+                >
+                  <FormattedMessage defaultMessage="Cancel" />
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <span className="text-gray-800">
+                {bucket.priorityArea ? (
+                  PRIORITY_AREA_LABELS[bucket.priorityArea] ??
+                  bucket.priorityArea
+                ) : (
+                  <span className="text-gray-400 italic">
+                    <FormattedMessage defaultMessage="Not set" />
+                  </span>
+                )}
+              </span>
+              {canEdit && (
+                <Tooltip
+                  content={intl.formatMessage({
+                    defaultMessage: "Edit priority area",
+                  })}
+                  placement="bottom"
+                  arrow={false}
+                >
+                  <IconButton onClick={() => setEditingPriorityArea(true)}>
+                    <EditIcon className="h-4 w-4" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {showSourceFunding && (
+        <div>
+          <div className="text-sm font-medium text-gray-500 mb-1">
+            <FormattedMessage defaultMessage="Source of additional funding" />
+          </div>
+          {editingSourceFunding ? (
+            <div>
+              <select
+                className="border rounded px-2 py-1 text-sm w-full mb-2"
+                value={sourceFundingValue}
+                onChange={(e) => setSourceFundingValue(e.target.value)}
+                autoFocus
+              >
+                <option value="">—</option>
+                {sourceFundingOptions.map((key) => (
+                  <option key={key} value={key}>
+                    {SOURCE_FUNDING_LABELS[key] ?? key}
+                  </option>
+                ))}
+              </select>
+              <div className="flex gap-2">
+                <Button
+                  size="small"
+                  loading={savingSourceFunding}
+                  onClick={() =>
+                    saveSourceFunding({
+                      bucketId: bucket.id,
+                      sourceFunding: sourceFundingValue || null,
+                    }).then(({ error }) => {
+                      if (error) alert(error.message);
+                      else setEditingSourceFunding(false);
+                    })
+                  }
+                >
+                  <FormattedMessage defaultMessage="Save" />
+                </Button>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() => {
+                    setSourceFundingValue(bucket.sourceFunding ?? "");
+                    setEditingSourceFunding(false);
+                  }}
+                >
+                  <FormattedMessage defaultMessage="Cancel" />
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <span className="text-gray-800">
+                {bucket.sourceFunding ? (
+                  SOURCE_FUNDING_LABELS[bucket.sourceFunding] ??
+                  bucket.sourceFunding
+                ) : (
+                  <span className="text-gray-400 italic">
+                    <FormattedMessage defaultMessage="Not set" />
+                  </span>
+                )}
+              </span>
+              {canEdit && (
+                <Tooltip
+                  content={intl.formatMessage({
+                    defaultMessage: "Edit source of funding",
+                  })}
+                  placement="bottom"
+                  arrow={false}
+                >
+                  <IconButton onClick={() => setEditingSourceFunding(true)}>
+                    <EditIcon className="h-4 w-4" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+    </div>
+  );
+};
+
+export default BucketExtraFields;

--- a/ui/components/Bucket/KeyFundCommentary.tsx
+++ b/ui/components/Bucket/KeyFundCommentary.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { gql, useMutation } from "urql";
+import Tooltip from "@tippyjs/react";
+
+import Button from "components/Button";
+import IconButton from "components/IconButton";
+import { EditIcon } from "components/Icons";
+
+const EDIT_KEY_FUND_COMMENTARY = gql`
+  mutation EditBucketKeyFundCommentary(
+    $bucketId: ID!
+    $keyFundCommentary: String
+  ) {
+    editBucket(bucketId: $bucketId, keyFundCommentary: $keyFundCommentary) {
+      id
+      keyFundCommentary
+    }
+  }
+`;
+
+const KeyFundCommentary = ({
+  bucket,
+  canEdit,
+}: {
+  bucket: any;
+  canEdit: boolean;
+}) => {
+  const intl = useIntl();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(bucket.keyFundCommentary ?? "");
+  const [{ fetching }, saveCommentary] = useMutation(EDIT_KEY_FUND_COMMENTARY);
+
+  if (!bucket.keyFundCommentary && !canEdit) return null;
+
+  if (editing) {
+    return (
+      <div className="mb-4">
+        <textarea
+          className="border rounded px-3 py-2 text-sm w-full"
+          rows={5}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          autoFocus
+        />
+        <div className="flex justify-end items-center mb-4">
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setValue(bucket.keyFundCommentary ?? "");
+                setEditing(false);
+              }}
+            >
+              <FormattedMessage defaultMessage="Cancel" />
+            </Button>
+            <Button
+              loading={fetching}
+              onClick={() =>
+                saveCommentary({
+                  bucketId: bucket.id,
+                  keyFundCommentary: value || null,
+                }).then(({ error }) => {
+                  if (error) alert(error.message);
+                  else setEditing(false);
+                })
+              }
+            >
+              <FormattedMessage defaultMessage="Save" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (bucket.keyFundCommentary) {
+    return (
+      <div className="relative mb-4">
+        <p className="whitespace-pre-line text-gray-800">
+          {bucket.keyFundCommentary}
+        </p>
+        {canEdit && (
+          <div className="absolute top-0 right-0">
+            <Tooltip
+              content={intl.formatMessage({ defaultMessage: "Edit commentary" })}
+              placement="bottom"
+              arrow={false}
+            >
+              <IconButton onClick={() => setEditing(true)}>
+                <EditIcon className="h-6 w-6" />
+              </IconButton>
+            </Tooltip>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (canEdit) {
+    return (
+      <button
+        onClick={() => setEditing(true)}
+        className="block w-full h-24 text-gray-600 font-semibold rounded-lg border-3 border-dashed focus:outline-none focus:bg-gray-100 hover:bg-gray-100 mb-4"
+      >
+        <FormattedMessage defaultMessage="+ Key Fund commentary" />
+      </button>
+    );
+  }
+
+  return null;
+};
+
+export default KeyFundCommentary;

--- a/ui/components/Bucket/index.tsx
+++ b/ui/components/Bucket/index.tsx
@@ -5,6 +5,8 @@ import Budget from "./Budget";
 import Description from "./Description";
 import BucketCustomFields from "./CustomFields/BucketCustomFields";
 import DirectFunding from "./DirectFunding";
+import ExtraFields from "./ExtraFields";
+import KeyFundCommentary from "./KeyFundCommentary";
 import toast from "react-hot-toast";
 
 const Bucket = ({ bucket, currentUser, openImageModal }) => {
@@ -63,6 +65,10 @@ const Bucket = ({ bucket, currentUser, openImageModal }) => {
                 canEdit={canEdit}
               />
             )}
+
+            <KeyFundCommentary bucket={bucket} canEdit={canEdit} />
+
+            <ExtraFields bucket={bucket} canEdit={canEdit} />
 
             <BucketCustomFields
               roundId={bucket.round.id}

--- a/ui/pages/[group]/[round]/[bucket]/index.tsx
+++ b/ui/pages/[group]/[round]/[bucket]/index.tsx
@@ -53,6 +53,9 @@ export const BUCKET_QUERY = gql`
       exchangeDescription
       exchangeMinimumContribution
       exchangeVat
+      priorityArea
+      sourceFunding
+      keyFundCommentary
 
       expenses {
         id

--- a/ui/server/graphql/resolvers/mutations/bucket.ts
+++ b/ui/server/graphql/resolvers/mutations/bucket.ts
@@ -150,6 +150,9 @@ export const editBucket = combineResolvers(
       exchangeDescription,
       exchangeMinimumContribution,
       exchangeVat,
+      priorityArea,
+      sourceFunding,
+      keyFundCommentary,
     },
     { user, eventHub }
   ) => {
@@ -188,6 +191,9 @@ export const editBucket = combineResolvers(
         exchangeDescription,
         exchangeMinimumContribution,
         exchangeVat,
+        priorityArea,
+        sourceFunding,
+        keyFundCommentary,
       },
       include: {
         Images: true,

--- a/ui/server/graphql/schema/index.js
+++ b/ui/server/graphql/schema/index.js
@@ -253,6 +253,9 @@ const schema = gql`
       exchangeDescription: String
       exchangeMinimumContribution: Int
       exchangeVat: Int
+      priorityArea: String
+      sourceFunding: String
+      keyFundCommentary: String
     ): Bucket
     deleteBucket(bucketId: ID!): Bucket
 
@@ -782,6 +785,9 @@ const schema = gql`
     exchangeDescription: String
     exchangeMinimumContribution: Int
     exchangeVat: Int
+    priorityArea: String
+    sourceFunding: String
+    keyFundCommentary: String
     percentageFunded: Float
     expenses: [Expense]
     expense(id: String!): Expense

--- a/ui/server/prisma/migrations/20260611200539_add_bucket_additional_fields/migration.sql
+++ b/ui/server/prisma/migrations/20260611200539_add_bucket_additional_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Bucket" ADD COLUMN     "keyFundCommentary" TEXT,
+ADD COLUMN     "priorityArea" TEXT,
+ADD COLUMN     "sourceFunding" TEXT;

--- a/ui/server/prisma/schema.prisma
+++ b/ui/server/prisma/schema.prisma
@@ -364,6 +364,10 @@ model Bucket {
   exchangeMinimumContribution Int               @default(0)
   exchangeVat                 Int?
 
+  priorityArea      String?
+  sourceFunding     String?
+  keyFundCommentary String?
+
   deleted           Boolean        @default(false)
   discourseTopicId  Int?
   flags             Flag[]


### PR DESCRIPTION


Adds three new optional fields to the Bucket model for Give it a Go / Key Fund metadata storage:

- priorityArea (String?) — single-select, options env-var-driven with defaults
- sourceFunding (String?) — single-select, options env-var-driven with defaults
- keyFundCommentary (String?) — long-text, free-form

Changes:
- Prisma schema + migration (20260611200539_add_bucket_additional_fields)
- GraphQL Bucket type + editBucket mutation extended
- editBucket resolver passes new fields through
- BUCKET_QUERY updated to fetch all three fields
- ExtraFields.tsx: displays priority area + source funding as 2-col grid (desktop) with inline dropdown edit; env-var-driven options with defaults
- KeyFundCommentary.tsx: displays commentary as plain text matching Description visual pattern; inline textarea edit
- Both rendered in main Bucket content tab: Images → Description → Commentary → Dropdowns → Budget

Values are intended to be populated at import time via CSV script (C-15). No env vars required (defaults cover all options out of the box).

Pre-deploy: run Prisma migration against the target DB.