### PR TITLE
temp(give-it-a-go): hide non-essential UI tabs, pages, and options

### DIFF
--- a/ui/components/Bucket/Sidebar.tsx
+++ b/ui/components/Bucket/Sidebar.tsx
@@ -639,47 +639,7 @@ const BucketSidebar = ({
                     <FormattedMessage defaultMessage="Unapprove for funding" />
                   </button>
                 )}
-                {isAdminOrModerator && (
-                  <>
-                    {bucket.pinnedAt ? (
-                      <button
-                        className={`${css.dropdownButton} !text-black`}
-                        onClick={() =>
-                          pinBucket({ bucketId: bucket.id, pin: false }).then(
-                            ({ error }) => {
-                              if (error) {
-                                toast.error(error.message);
-                              } else {
-                                toast.success("Bucket unpinned");
-                                setActionsDropdownOpen(false);
-                              }
-                            }
-                          )
-                        }
-                      >
-                        Unpin
-                      </button>
-                    ) : (
-                      <button
-                        className={`${css.dropdownButton} !text-black`}
-                        onClick={() =>
-                          pinBucket({ bucketId: bucket.id, pin: true }).then(
-                            ({ error }) => {
-                              if (error) {
-                                toast.error(error.message);
-                              } else {
-                                toast.success("Bucket pinned");
-                                setActionsDropdownOpen(false);
-                              }
-                            }
-                          )
-                        }
-                      >
-                        Pin
-                      </button>
-                    )}
-                  </>
-                )}
+                {/* [TEMP: give-it-a-go] Pin/Unpin hidden */}
                 {showDeleteButton && (
                   <button
                     className={css.dropdownButton}

--- a/ui/components/Group/Settings/index.tsx
+++ b/ui/components/Group/Settings/index.tsx
@@ -36,11 +36,7 @@ const GroupSettings = ({
         name: intl.formatMessage({ defaultMessage: "General" }),
         component: GeneralSettings,
       },
-      {
-        slug: "billing",
-        name: intl.formatMessage({ defaultMessage: "Billing" }),
-        component: Billing,
-      },
+      // [TEMP: give-it-a-go] Billing hidden
       ...(inSession
         ? [
             {

--- a/ui/components/ProfileDropdown.js
+++ b/ui/components/ProfileDropdown.js
@@ -91,16 +91,7 @@ const ProfileDropdown = ({ currentUser, setEditProfileModalOpen }) => {
             >
               <FormattedMessage defaultMessage="Edit profile" />
             </button>
-            <Link href="/settings">
-              <a className={css.button}>
-                <FormattedMessage defaultMessage="Email settings" />
-              </a>
-            </Link>
-            <Link href={"/starred-buckets"}>
-              <a className={css.button} onClick={() => setOpen(false)}>
-                ★ Buckets
-              </a>
-            </Link>
+            {/* [TEMP: give-it-a-go] Email settings and Starred Buckets hidden */}
             <a href="/api/auth/logout" className={css.button}>
               <FormattedMessage defaultMessage="Sign out" />
             </a>

--- a/ui/components/RoundMembers/MembersTable.tsx
+++ b/ui/components/RoundMembers/MembersTable.tsx
@@ -251,32 +251,7 @@ const ActionsDropdown = ({ roundId, updateMember, deleteMember, member }) => {
             <FormattedMessage defaultMessage="Invite Again" />
           </MenuItem>
         )}
-        <MenuItem
-          onClick={() => {
-            activityLog.log({
-              message: TOGGLE_ROUND_MODERATOR,
-              data: {
-                roundId,
-                memberEmail: member?.email,
-                newRole: member.isModerator
-                  ? "Removed moderator"
-                  : "Made moderator",
-              },
-            });
-
-            updateMember({
-              roundId,
-              memberId: member.id,
-              isModerator: !member.isModerator,
-            }).then(() => {
-              handleClose();
-            });
-          }}
-        >
-          {member.isModerator
-            ? intl.formatMessage({ defaultMessage: "Remove moderator" })
-            : intl.formatMessage({ defaultMessage: "Make moderator" })}
-        </MenuItem>
+        {/* [TEMP: give-it-a-go] Make/Remove moderator hidden */}
         <Tooltip
           content={intl.formatMessage({
             defaultMessage:
@@ -467,29 +442,8 @@ const RoundMembersTable = ({
                     <span className="block">
                       <FormattedMessage defaultMessage="Balance" />
                     </span>{" "}
-                    {isAdmin && (
-                      <Tooltip
-                        content={intl.formatMessage({
-                          defaultMessage: "Allocate to all members",
-                        })}
-                        placement="bottom"
-                        arrow={false}
-                      >
-                        <IconButton
-                          disabled={actionsAreDisabled}
-                          onClick={() => setBulkAllocateModalOpen(true)}
-                        >
-                          <AddIcon className="h-4 w-4" color={actionsAreDisabled ? "gray" : "currentColor"} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
+                    {/* [TEMP: give-it-a-go] Bulk Allocate button hidden */}
                   </div>
-                  {bulkAllocateModalOpen && (
-                    <BulkAllocateModal
-                      round={round}
-                      handleClose={() => setBulkAllocateModalOpen(false)}
-                    />
-                  )}
                 </TableCell>
                 {isAdmin && (
                   <TableCell align="right">

--- a/ui/components/RoundSettings/Granting/index.tsx
+++ b/ui/components/RoundSettings/Granting/index.tsx
@@ -229,92 +229,8 @@ const RoundSettingsModalGranting = ({ currentGroup }) => {
 
           <Divider />
 
-          <SettingsListItem
-            primary={intl.formatMessage({
-              defaultMessage: "Allow stretch goals",
-            })}
-            secondary={
-              round.allowStretchGoals ? (
-                <FormattedMessage defaultMessage="Yes" />
-              ) : (
-                <FormattedMessage defaultMessage="No" />
-              )
-            }
-            isSet={typeof round.allowStretchGoals !== "undefined"}
-            openModal={() => handleOpen("SET_ALLOW_STRETCH_GOALS")}
-            canEdit={canEditSettings}
-            roundColor={round.color}
-          />
+          {/* [TEMP: give-it-a-go] Allow stretch goals, Silent allocation, Co-creator permissions hidden */}
 
-          <Divider />
-
-          {/* --- Silent allocation (Give it a Go C-06) --- */}
-          {/* To hide this setting for an instance, comment out this block. */}
-          <SettingsListItem
-            primary={intl.formatMessage({
-              defaultMessage: "Silent allocation",
-            })}
-            secondary={
-              round.silentAllocation ? (
-                <FormattedMessage defaultMessage="Yes" />
-              ) : (
-                <FormattedMessage defaultMessage="No" />
-              )
-            }
-            isSet={typeof round.silentAllocation !== "undefined"}
-            openModal={() => handleOpen("SET_SILENT_ALLOCATION")}
-            canEdit={canEditSettings}
-            roundColor={round.color}
-          />
-          {/* --- end Silent allocation --- */}
-
-          <Divider />
-
-          <SettingsListItem
-            primary={intl.formatMessage(
-              {
-                defaultMessage: "Co-creators can open {bucketName} for funding",
-              },
-              {
-                bucketName: process.env.BUCKET_NAME_PLURAL,
-              }
-            )}
-            secondary={
-              round.canCocreatorStartFunding ? (
-                <FormattedMessage defaultMessage="Yes" />
-              ) : (
-                <FormattedMessage defaultMessage="No" />
-              )
-            }
-            isSet={typeof round.canCocreatorStartFunding !== "undefined"}
-            openModal={() => handleOpen("SET_COCREATOR_CAN_OPEN_FUNDING")}
-            canEdit={canEditSettings}
-            roundColor={round.color}
-          />
-          <Divider />
-
-          <SettingsListItem
-            primary={intl.formatMessage(
-              {
-                defaultMessage:
-                  "Co-creators can edit their {bucketName} during funding",
-              },
-              {
-                bucketName: process.env.BUCKET_NAME_SINGULAR,
-              }
-            )}
-            secondary={
-              round.canCocreatorEditOpenBuckets ? (
-                <FormattedMessage defaultMessage="Yes" />
-              ) : (
-                <FormattedMessage defaultMessage="No" />
-              )
-            }
-            isSet={typeof round.canCocreatorEditOpenBuckets !== "undefined"}
-            openModal={() => handleOpen("SET_COCREATOR_CAN_EDIT_OPEN_BUCKETS")}
-            canEdit={canEditSettings}
-            roundColor={round.color}
-          />
           <Divider />
 
           <SettingsListItem
@@ -466,19 +382,7 @@ const RoundSettingsModalGranting = ({ currentGroup }) => {
             </>
           )}
 
-          <Divider />
-          <div className="px-3 my-3">
-            <h2 className="text-xl font-semibold mt-8 mb-4">
-              <FormattedMessage defaultMessage="Danger Zone" />
-            </h2>
-            <Button
-              onClick={() => setOpenResetModal(true)}
-              variant="secondary"
-              color="red"
-            >
-              <FormattedMessage defaultMessage="Reset funding" />
-            </Button>
-          </div>
+          {/* [TEMP: give-it-a-go] Reset funding (Danger Zone) hidden */}
         </List>
       </div>
     </div>

--- a/ui/components/RoundSettings/index.tsx
+++ b/ui/components/RoundSettings/index.tsx
@@ -51,26 +51,7 @@ const RoundSettings = ({
         name: intl.formatMessage({ defaultMessage: "Guidelines" }),
         component: Guidelines,
       },
-      {
-        slug: "bucket-review",
-        name: intl.formatMessage(
-          {
-            defaultMessage: "{bucket} Review",
-          },
-          { bucket: capitalize(process.env.BUCKET_NAME_SINGULAR) }
-        ),
-        component: BucketReview,
-      },
-      {
-        slug: "bucket-form",
-        name: intl.formatMessage(
-          {
-            defaultMessage: "{bucket} Form",
-          },
-          { bucket: capitalize(process.env.BUCKET_NAME_SINGULAR) }
-        ),
-        component: CustomFields,
-      },
+      // [TEMP: give-it-a-go] Bucket Review, Bucket Form, Integrations hidden
       {
         slug: "funding",
         name: intl.formatMessage({ defaultMessage: "Funding" }),
@@ -80,11 +61,6 @@ const RoundSettings = ({
         slug: "tags",
         name: intl.formatMessage({ defaultMessage: "Tags" }),
         component: Tags,
-      },
-      {
-        slug: "integrations",
-        name: intl.formatMessage({ defaultMessage: "Integrations" }),
-        component: Integrations,
       },
       {
         slug: "group",

--- a/ui/components/SubMenu.tsx
+++ b/ui/components/SubMenu.tsx
@@ -66,10 +66,7 @@ export const roundItems = (
       label: formatMessage({ defaultMessage: "Overview" }),
       href: `/${groupSlug}/${roundSlug}`,
     },
-    {
-      label: formatMessage({ defaultMessage: "Feed" }),
-      href: `/${groupSlug}/${roundSlug}/image-feed`,
-    },
+    // [TEMP: give-it-a-go] Feed, History, Expenses, Budget Items hidden
     {
       label: formatMessage({ defaultMessage: "About" }),
       href: `/${groupSlug}/${roundSlug}/about`,
@@ -78,19 +75,6 @@ export const roundItems = (
       label: formatMessage({ defaultMessage: "Participants" }),
       href: `/${groupSlug}/${roundSlug}/participants`,
       member: true,
-    },
-    {
-      label: formatMessage({ defaultMessage: "History" }),
-      href: `/${groupSlug}/${roundSlug}/history`,
-      admin: true,
-    },
-    {
-      label: formatMessage({ defaultMessage: "Expenses" }),
-      href: `/${groupSlug}/${roundSlug}/expenses`,
-    },
-    {
-      label: formatMessage({ defaultMessage: "Budget Items" }),
-      href: `/${groupSlug}/${roundSlug}/budget-items`,
     },
     {
       label: formatMessage({ defaultMessage: "Settings" }),


### PR DESCRIPTION
Plain UI-only hiding (no server-side changes). All hidden elements are marked with [TEMP: give-it-a-go] comments for easy reversal.

Hidden tabs/pages:
- Round sub-menu: Feed, Expenses, Budget Items, History
- Round Settings tabs: Bucket Review, Bucket Form (Custom Fields), Integrations
- Group Settings tabs: Billing
- Profile dropdown: Email settings, Starred Buckets

Hidden granular items:
- Funding settings: Allow stretch goals, Silent allocation, Co-creator permissions, Reset funding (Danger Zone)
- Bucket sidebar More Actions: Pin/Unpin
- Round Members table: Bulk Allocate button, Make/Remove moderator