### PR TITLE
temp(give-it-a-go): restore silent allocation toggle; hide marketing …

### DIFF
--- a/ui/components/RequiredActions/FinishSignup.tsx
+++ b/ui/components/RequiredActions/FinishSignup.tsx
@@ -81,20 +81,7 @@ export default function FinishSignup({ currentUser }) {
           }}
           testid="signup-user-username"
         />
-        <FormControlLabel
-          control={
-            <div className="-mt-12 pt-0.5">
-              <Checkbox
-                value={mailUpdates}
-                onChange={(evt) => setMailUpdates(evt.target.checked)}
-              />
-            </div>
-          }
-          label={intl.formatMessage({
-            defaultMessage:
-              "I would like occasional emails about product updates and Cobudget-related events, trainings, and support resources.",
-          })}
-        />
+        {/* [TEMP: give-it-a-go] Marketing opt-in checkbox hidden — not appropriate for this instance */}
         {process.env.TERMS_URL && (
           <label className="text-sm flex items-center space-x-2">
             <FormControlLabel

--- a/ui/components/RoundSettings/Granting/index.tsx
+++ b/ui/components/RoundSettings/Granting/index.tsx
@@ -229,7 +229,24 @@ const RoundSettingsModalGranting = ({ currentGroup }) => {
 
           <Divider />
 
-          {/* [TEMP: give-it-a-go] Allow stretch goals, Silent allocation, Co-creator permissions hidden */}
+          {/* [TEMP: give-it-a-go] Allow stretch goals, Co-creator permissions hidden */}
+
+          <SettingsListItem
+            primary={intl.formatMessage({
+              defaultMessage: "Silent allocation",
+            })}
+            secondary={
+              round.silentAllocation ? (
+                <FormattedMessage defaultMessage="Yes" />
+              ) : (
+                <FormattedMessage defaultMessage="No" />
+              )
+            }
+            isSet={typeof round.silentAllocation !== "undefined"}
+            openModal={() => handleOpen("SET_SILENT_ALLOCATION")}
+            canEdit={canEditSettings}
+            roundColor={round.color}
+          />
 
           <Divider />
 


### PR DESCRIPTION
…opt-in

- Restore Silent allocation toggle in Funding settings (actively used for this instance's event flow)
- Hide marketing opt-in checkbox from FinishSignup dialog — not appropriate for a client-specific instance

Both changes marked [TEMP: give-it-a-go] for easy reversal.