### PR TITLE
Add DISABLE_WELCOME_EMAIL env var to suppress onboarding email

### DIFF
--- a/ui/server/passport/helpers.ts
+++ b/ui/server/passport/helpers.ts
@@ -57,7 +57,9 @@ export async function createOrGetUser({
 
   if (olderUser?.verifiedEmail !== newerUser.verifiedEmail) {
     // if true then it's a new user
-    await emailService.welcomeEmail({ newUser: newerUser });
+    if (!process.env.DISABLE_WELCOME_EMAIL) {
+      await emailService.welcomeEmail({ newUser: newerUser });
+    }
   }
 
   return newerUser;


### PR DESCRIPTION
Wraps the welcomeEmail call in a process.env.DISABLE_WELCOME_EMAIL guard. When the env var is set, new users do not receive the Cobudget marketing welcome email on first login. Existing deployments that do not set the env var are unaffected.

This is a general-purpose opt-out mechanism — suitable for upstream contribution. Any Cobudget deployment can set DISABLE_WELCOME_EMAIL=true to suppress the onboarding email without code changes.