### PR TITLE
Fix magic link URL truncation by stripping captchaToken from JWT payload

### DIFF
--- a/ui/pages/api/auth/magiclink/index.ts
+++ b/ui/pages/api/auth/magiclink/index.ts
@@ -4,6 +4,8 @@ import magicLink from "../../../../server/passport/magicLink";
 export default handler().post(async (req: any, res: any) => {
   const { captchaToken } = req.body;
 
+  delete req.body.captchaToken;
+
   if (process.env.SKIP_RECAPTCHA === "true") {
     return magicLink.send(req, res);
   }


### PR DESCRIPTION
The captcha token was being included in the JWT via passport-magic-login spreading the entire req.body. This bloated the magic link URL to ~4KB, causing some email clients (e.g. Outlook, corporate mail proxies) to truncate the link, resulting in a malformed JWT at the callback.

The captcha is verified server-side before the JWT is signed — it has no purpose in the callback payload. Stripping it keeps the token to a few hundred bytes.