### PR TITLE
[TEMP: give-it-a-go] Hide About tab from non-admin users

### DIFF
--- a/ui/components/SubMenu.tsx
+++ b/ui/components/SubMenu.tsx
@@ -70,6 +70,7 @@ export const roundItems = (
     {
       label: formatMessage({ defaultMessage: "About" }),
       href: `/${groupSlug}/${roundSlug}/about`,
+      admin: true, // [TEMP: give-it-a-go] About tab hidden from non-admins — not relevant to participants
     },
     {
       label: formatMessage({ defaultMessage: "Participants" }),


### PR DESCRIPTION
Not relevant to participants; also avoids exposing round configuration details (sorting numbers etc.) to regular users.