### PR TITLE
fix(011): JS-gated confirm page to prevent email scanner token consum…

### DIFF
--- a/ui/pages/api/auth/magiclink/callback.ts
+++ b/ui/pages/api/auth/magiclink/callback.ts
@@ -4,6 +4,10 @@ import jwt from "jsonwebtoken";
 import prisma from "server/prisma";
 
 export default handler()
+  .use((req, res, next) => {
+    if (req.method === "HEAD") return res.status(405).end();
+    next();
+  })
   .use(async (req, res, next) => {
     const { token } = req.query;
     const payload = jwt.verify(token, process.env.MAGIC_LINK_SECRET);

--- a/ui/pages/magiclink-confirm.tsx
+++ b/ui/pages/magiclink-confirm.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { LoaderIcon } from "components/Icons";
+
+function MagiclinkConfirm() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const token = router.query.token;
+    if (!token) {
+      router.replace("/login?error=invalid-token");
+      return;
+    }
+    window.location.replace(
+      `/api/auth/magiclink/callback?token=${encodeURIComponent(token as string)}`
+    );
+  }, [router.isReady, router.query.token]);
+
+  return (
+    <div className="page flex flex-col items-center justify-center text-gray-500">
+      <LoaderIcon className="animate-spin" width={32} height={32} />
+      <p className="mt-4">Signing you in…</p>
+    </div>
+  );
+}
+
+export default MagiclinkConfirm;

--- a/ui/server/passport/magicLink.ts
+++ b/ui/server/passport/magicLink.ts
@@ -9,7 +9,7 @@ if (!process.env.MAGIC_LINK_SECRET)
 
 const magicLink = new MagicLoginStrategy({
   secret: process.env.MAGIC_LINK_SECRET,
-  callbackUrl: "/api/auth/magiclink/callback",
+  callbackUrl: "/magiclink-confirm",
   sendMagicLink: async (destination, href, code, req) => {
     const user = await prisma.user.findUnique({
       where: { email: destination },


### PR DESCRIPTION
…ption

Safe Links and similar corporate scanners issue GET requests that consume single-use magic link tokens before the user clicks. The fix interposes a /magiclink-confirm page: scanners fetch it and get plain HTML; the useEffect that fires the real callback never runs without JS execution.

- New ui/pages/magiclink-confirm.tsx: spinner + useEffect window.location.replace
- magicLink.ts: callbackUrl changed from /api/auth/magiclink/callback to /magiclink-confirm
- callback.ts: HEAD → 405 added as defense-in-depth