### PR TITLE
feat(013): Short Text fields support autocomplete suggestions

### DIFF
--- a/ui/components/Bucket/CustomFields/BucketCustomField.tsx
+++ b/ui/components/Bucket/CustomFields/BucketCustomField.tsx
@@ -123,7 +123,29 @@ const BucketCustomField = ({
             inputRef={register()}
           />
           <div className="my-2">
-            {defaultCustomField.type === "TEXT" ||
+            {defaultCustomField.type === "TEXT" &&
+            (defaultCustomField.options ?? []).length > 0 ? (
+              <>
+                <TextField
+                  placeholder={defaultCustomField.name}
+                  defaultValue={defaultValue}
+                  autoFocus
+                  error={errors.customField?.value}
+                  helperText={errors.customField?.value?.message}
+                  inputProps={{
+                    list: `datalist-${defaultCustomField.id}`,
+                    maxLength: defaultCustomField.limit ?? undefined,
+                    onChange: (e) =>
+                      setValue("customField.value", e.target.value),
+                  }}
+                />
+                <datalist id={`datalist-${defaultCustomField.id}`}>
+                  {(defaultCustomField.options ?? []).map((opt) => (
+                    <option key={opt} value={opt} />
+                  ))}
+                </datalist>
+              </>
+            ) : defaultCustomField.type === "TEXT" ||
             defaultCustomField.type === "MULTILINE_TEXT" ? (
               <TextField
                 placeholder={defaultCustomField.name}

--- a/ui/components/RoundSettings/CustomFields/AddOrEditCustomField.js
+++ b/ui/components/RoundSettings/CustomFields/AddOrEditCustomField.js
@@ -207,10 +207,22 @@ export default function AddOrEditCustomField({
                 />
               ) : null}
             </div>
-            {(typeInputValue === "ENUM" || typeInputValue === "TEXT") && (
+            {typeInputValue === "ENUM" && (
               <TextField
                 placeholder={intl.formatMessage({
                   defaultMessage: "Options (comma-separated)",
+                })}
+                color={round.color}
+                inputProps={{
+                  value: optionsInput,
+                  onChange: (e) => setOptionsInput(e.target.value),
+                }}
+              />
+            )}
+            {typeInputValue === "TEXT" && (
+              <TextField
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Autocomplete suggestions (comma-separated)",
                 })}
                 color={round.color}
                 inputProps={{

--- a/ui/components/RoundSettings/CustomFields/AddOrEditCustomField.js
+++ b/ui/components/RoundSettings/CustomFields/AddOrEditCustomField.js
@@ -123,7 +123,7 @@ export default function AddOrEditCustomField({
           onSubmit={handleSubmit((variables) => {
             variables.customField.isRequired = isRequired;
             variables.customField.options =
-              typeInputValue === "ENUM"
+              typeInputValue === "ENUM" || typeInputValue === "TEXT"
                 ? optionsInput.split(",").map((s) => s.trim()).filter(Boolean)
                 : [];
             return addOrEditCustomField({
@@ -207,7 +207,7 @@ export default function AddOrEditCustomField({
                 />
               ) : null}
             </div>
-            {typeInputValue === "ENUM" && (
+            {(typeInputValue === "ENUM" || typeInputValue === "TEXT") && (
               <TextField
                 placeholder={intl.formatMessage({
                   defaultMessage: "Options (comma-separated)",

--- a/ui/components/RoundSettings/CustomFields/DraggableCustomFields.js
+++ b/ui/components/RoundSettings/CustomFields/DraggableCustomFields.js
@@ -73,6 +73,7 @@ const SortableItem = sortableElement(
       TEXT: intl.formatMessage({ defaultMessage: "Short Text" }),
       MULTILINE_TEXT: intl.formatMessage({ defaultMessage: "Long Text" }),
       BOOLEAN: intl.formatMessage({ defaultMessage: "Yes/No" }),
+      ENUM: intl.formatMessage({ defaultMessage: "Select (dropdown)" }),
     };
 
     return (


### PR DESCRIPTION
## Summary

- **Form Builder** (`AddOrEditCustomField.js`): Short Text fields now show an "Autocomplete suggestions (comma-separated)" input, letting admins attach hint values to a free-text field. ENUM fields keep their existing "Options (comma-separated)" input unchanged.
- **Bucket form** (`BucketCustomField.tsx`): Short Text fields with at least one suggestion render as a native `<input>` + `<datalist>` — participants can type freely or pick from the list; any value is accepted. Short Text fields with no suggestions fall back to the existing plain text input (no regression). ENUM fields unchanged.
- **Field list view** (`DraggableCustomFields.js`): Fixed a missing label — ENUM fields now show "Type: Select (dropdown)" in the Bucket Form settings list (was blank).

Targets `feat-012` because it depends on the `options String[]` column added in that worktrack.

## Motivation

Priority Area is imported from PDFs with values that don't always match a fixed option list. Switching from ENUM (locked select) to Short Text + autocomplete suggestions lets any value through while still guiding participants toward the standard categories.

## No schema changes

`options String[]` and `limit Int?` were already on the `Field` model (worktrack 012). No Prisma migration, no GraphQL changes needed.

## Test plan

- [ ] Create a Short Text field with suggestions in Round Settings → Bucket Form
- [ ] Open a bucket form as a participant — confirm suggestions appear as you type
- [ ] Submit a value not in the list — confirm it saves correctly
- [ ] Create a Short Text field with no suggestions — confirm plain text input (no datalist)
- [ ] Create an ENUM field — confirm select dropdown unchanged
- [ ] Check the Bucket Form field list — confirm "Type: Select (dropdown)" shows for ENUM fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)