### PR TITLE
fix: magic link scanner token consumption (prod backport)

### DIFF
--- a/ui/pages/api/auth/magiclink/callback.ts
+++ b/ui/pages/api/auth/magiclink/callback.ts
@@ -4,6 +4,10 @@ import jwt from "jsonwebtoken";
 import prisma from "server/prisma";
 
 export default handler()
+  .use((req, res, next) => {
+    if (req.method === "HEAD") return res.status(405).end();
+    next();
+  })
   .use(async (req, res, next) => {
     const { token } = req.query;
     const payload = jwt.verify(token, process.env.MAGIC_LINK_SECRET);

--- a/ui/pages/api/auth/magiclink/index.ts
+++ b/ui/pages/api/auth/magiclink/index.ts
@@ -4,6 +4,8 @@ import magicLink from "../../../../server/passport/magicLink";
 export default handler().post(async (req: any, res: any) => {
   const { captchaToken } = req.body;
 
+  delete req.body.captchaToken;
+
   if (process.env.SKIP_RECAPTCHA === "true") {
     return magicLink.send(req, res);
   }

--- a/ui/pages/magiclink-confirm.tsx
+++ b/ui/pages/magiclink-confirm.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { LoaderIcon } from "components/Icons";
+
+function MagiclinkConfirm() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const token = router.query.token;
+    if (!token) {
+      router.replace("/login?error=invalid-token");
+      return;
+    }
+    window.location.replace(
+      `/api/auth/magiclink/callback?token=${encodeURIComponent(token as string)}`
+    );
+  }, [router.isReady, router.query.token]);
+
+  return (
+    <div className="page flex flex-col items-center justify-center text-gray-500">
+      <LoaderIcon className="animate-spin" width={32} height={32} />
+      <p className="mt-4">Signing you in…</p>
+    </div>
+  );
+}
+
+export default MagiclinkConfirm;

--- a/ui/server/passport/magicLink.ts
+++ b/ui/server/passport/magicLink.ts
@@ -9,7 +9,7 @@ if (!process.env.MAGIC_LINK_SECRET)
 
 const magicLink = new MagicLoginStrategy({
   secret: process.env.MAGIC_LINK_SECRET,
-  callbackUrl: "/api/auth/magiclink/callback",
+  callbackUrl: "/magiclink-confirm",
   sendMagicLink: async (destination, href, code, req) => {
     const user = await prisma.user.findUnique({
       where: { email: destination },


### PR DESCRIPTION
## Summary

Backport of two magic link fixes from `give-it-a-go` to `prod`. Both commits cherry-picked cleanly with no conflicts.

- **Captcha token bloat** (`5944d7d8`): strips `captchaToken` from JWT payload before signing. The captcha is verified server-side and has no purpose in the callback — its presence was bloating the magic link URL to ~4KB, causing truncation in Outlook and corporate mail proxies.
- **JS-gated confirm page** (`6906367a`): interposes `/magiclink-confirm` between the emailed link and the real callback. Email security scanners (Safe Links, etc.) fetch the confirm page and get plain HTML — the `useEffect` that fires `window.location.replace` to the real callback never runs without JS execution. Adds HEAD → 405 as defense-in-depth on the callback.

## Background

Confirmed via Vercel log analysis (2026-06-25): `daniel.heusser@wwf.ch` (WWF corporate domain) triggered HEAD scanner requests hitting `/api/auth/magiclink/callback` immediately after magic link sends — twice in the same day, suggesting the first attempt was consumed by the scanner. The fix was already live on `give-it-a-go`; `prod` was still vulnerable.

Reproduction confirmed manually: sending a HEAD request to a valid callback URL before clicking the link causes the "login link expired or invalid" error.

## Test plan

- [ ] Request a magic link on prod after deploy
- [ ] Confirm the emailed link points to `/magiclink-confirm?token=...` (not directly to `/api/auth/magiclink/callback`)
- [ ] Click the link — spinner shows briefly, then redirects to app and logs in
- [ ] Send HEAD to a fresh callback URL before clicking — confirm it returns 405
- [ ] Send HEAD to `/magiclink-confirm` URL — confirm token is NOT consumed (GET still works after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)