### PR TITLE
fix: allocate single member crashes with prisma transaction callback

### DIFF
--- a/ui/server/graphql/resolvers/mutations/round.ts
+++ b/ui/server/graphql/resolvers/mutations/round.ts
@@ -550,15 +550,13 @@ export const allocate = async (
   if (!currentCollMember?.isAdmin)
     throw new Error("You are not admin for this round");
 
-  await prisma.$transaction(async (prisma) => {
-    await allocateToMember({
-      member: targetRoundMember,
-      roundId: targetRoundMember.roundId,
-      amount,
-      type,
-      allocatedBy: currentCollMember.id,
-      prisma: prisma as any,
-    });
+  await allocateToMember({
+    member: targetRoundMember,
+    roundId: targetRoundMember.roundId,
+    amount,
+    type,
+    allocatedBy: currentCollMember.id,
+    prisma: prisma as any,
   });
 
   return targetRoundMember;


### PR DESCRIPTION
## Summary

- `allocate` (single-member token grant) called `prisma.$transaction(async fn => {...})` — the interactive/callback form
- This Prisma version only supports the array form (`$transaction([p1, p2, ...])`)
- The callback form routes internally to `_transactionWithArray`, which calls `.map()` on a function argument and throws `promises.map is not a function`
- Fix: call `allocateToMember` directly with the global `prisma` instance, matching the pattern already used by `bulkAllocate`

## Test plan

- [ ] As admin, grant tokens to a single member via the member list — no error, balance updates
- [ ] Verify bulk grant (grant to all) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)