### PR TITLE
fix: raise allocate transaction timeout, publish event outside tx

### DIFF
--- a/ui/pages/api/stripe/webhooks/connect.ts
+++ b/ui/pages/api/stripe/webhooks/connect.ts
@@ -3,6 +3,7 @@ import handler from "server/api-handler";
 import { allocateToMember, contribute } from "server/controller";
 import prisma from "server/prisma";
 import stripe from "server/stripe";
+import eventHub from "server/services/eventHub.service";
 
 export const config = {
   api: {
@@ -56,26 +57,35 @@ export default handler().post(async (req, res) => {
       },
     });
 
-    await prisma.$transaction(async (prisma) => {
-      await allocateToMember({
-        roundId,
-        allocatedBy: roundMemberId,
-        amount: contribution,
-        member: roundMember,
-        type: "ADD",
-        stripeSessionId,
-        prisma,
-      });
+    const eventData = await prisma.$transaction(
+      async (prisma) => {
+        const eventData = await allocateToMember({
+          roundId,
+          allocatedBy: roundMemberId,
+          amount: contribution,
+          member: roundMember,
+          type: "ADD",
+          stripeSessionId,
+          prisma,
+        });
 
-      await contribute({
-        roundId,
-        bucketId,
-        amount: contribution,
-        user: roundMember.user,
-        stripeSessionId,
-        prisma,
-      });
-    });
+        await contribute({
+          roundId,
+          bucketId,
+          amount: contribution,
+          user: roundMember.user,
+          stripeSessionId,
+          prisma,
+        });
+
+        return eventData;
+      },
+      { timeout: 15000 }
+    );
+
+    if (eventData) {
+      await eventHub.publish("allocate-to-member", eventData);
+    }
   } else {
     console.log(`Unhandled event type ${event.type}`);
   }

--- a/ui/server/controller/index.ts
+++ b/ui/server/controller/index.ts
@@ -53,7 +53,7 @@ export const allocateToMember = async ({
 
     adjustedAmount = amount - balance;
   }
-  if (adjustedAmount === 0) return;
+  if (adjustedAmount === 0) return null;
 
   try {
     await prisma.allocation.create({
@@ -79,12 +79,12 @@ export const allocateToMember = async ({
       },
     });
 
-    await eventHub.publish("allocate-to-member", {
+    return {
       roundMemberId: member.id,
       roundId,
       oldAmount: balance,
       newAmount: balance + adjustedAmount,
-    });
+    };
   } catch (error) {
     throw new Error("Failed to allocate to member: " + error.message);
   }

--- a/ui/server/graphql/resolvers/mutations/round.ts
+++ b/ui/server/graphql/resolvers/mutations/round.ts
@@ -550,16 +550,23 @@ export const allocate = async (
   if (!currentCollMember?.isAdmin)
     throw new Error("You are not admin for this round");
 
-  await prisma.$transaction(async (prisma) => {
-    await allocateToMember({
-      member: targetRoundMember,
-      roundId: targetRoundMember.roundId,
-      amount,
-      type,
-      allocatedBy: currentCollMember.id,
-      prisma: prisma as any,
-    });
-  });
+  const eventData = await prisma.$transaction(
+    async (prisma) => {
+      return allocateToMember({
+        member: targetRoundMember,
+        roundId: targetRoundMember.roundId,
+        amount,
+        type,
+        allocatedBy: currentCollMember.id,
+        prisma: prisma as any,
+      });
+    },
+    { timeout: 15000 }
+  );
+
+  if (eventData) {
+    await eventHub.publish("allocate-to-member", eventData);
+  }
 
   return targetRoundMember;
 };


### PR DESCRIPTION
## Summary
- Individual "Manage member's balance" allocation (and the Stripe connect webhook allocation path) wraps 3 sequential DB round-trips in an interactive Prisma transaction with the default 5000ms timeout. Under concurrent live-event load this intermittently exceeds the timeout (`Transaction already closed`), matching the bug Ed hit today (2026-07-07).
- Bulk allocate (add-to-everyone) is unaffected — it already uses a batched, non-interactive transaction.

## Change
- Raise the interactive transaction timeout to 15000ms on both call sites (`allocate` resolver, Stripe connect webhook).
- Move the non-DB `eventHub.publish("allocate-to-member", ...)` call outside the transaction so it no longer counts against the transaction's time budget.

## Test plan
- [ ] `tsc --noEmit` shows no new errors vs. base branch (verified: 13 pre-existing errors before, 12 after — no new errors introduced; remaining are a stale generated Prisma client type issue unrelated to this change)
- [ ] Manually allocate to an individual member on staging/prod and confirm balance updates + notification email still fires
- [ ] Confirm Stripe connect webhook allocation path still fires the `allocate-to-member` event (unit/manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)