### PR TITLE
hotfix: missing eventHub import in round.ts (prod broken since #1277)

### DIFF
--- a/ui/server/graphql/resolvers/mutations/round.ts
+++ b/ui/server/graphql/resolvers/mutations/round.ts
@@ -19,6 +19,7 @@ import {
 } from "../helpers";
 import { verify } from "server/utils/jwt";
 import emailService from "server/services/EmailService/email.service";
+import eventHub from "server/services/eventHub.service";
 import {
   inviteRoundMembersHelper,
   limitCheckedRoundMembers


### PR DESCRIPTION
## Summary
- PR #1277 moved the \`eventHub.publish\` call for individual balance allocation from \`controller/index.ts\` into \`round.ts\`, but the import was missed. Every individual "Manage member's balance" allocate call has been throwing \`eventHub is not defined\` in prod since that merge.
- One-line fix: add the missing import.

## Test plan
- [ ] Merge and confirm individual balance allocation (Manage member's balance modal) succeeds in prod with no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)