### PR TITLE
fix: widen inviteNonce to BigInt on prod (Round + Group)

### DIFF
--- a/ui/server/graphql/resolvers/mutations/group.ts
+++ b/ui/server/graphql/resolvers/mutations/group.ts
@@ -19,7 +19,7 @@ export const createGroupInvitationLink = combineResolvers(
       data: { inviteNonce },
     });
     return {
-      link: round.inviteNonce,
+      link: round.inviteNonce == null ? null : String(round.inviteNonce),
     };
   }
 );

--- a/ui/server/graphql/resolvers/mutations/round.ts
+++ b/ui/server/graphql/resolvers/mutations/round.ts
@@ -236,7 +236,7 @@ export const createInvitationLink = async (
     data: { inviteNonce },
   });
   return {
-    link: round.inviteNonce,
+    link: round.inviteNonce == null ? null : String(round.inviteNonce),
   };
 };
 
@@ -277,7 +277,8 @@ export const joinInvitationLink = async (parent, { token }, { user }) => {
     throw new Error("Invalid invitation link");
   }
 
-  const { roundId, groupId, nonce: inviteNonce } = payload;
+  const { roundId, groupId, nonce } = payload;
+  const inviteNonce = BigInt(nonce);
 
   if (roundId) {
     const round = await prisma.round.findFirst({

--- a/ui/server/graphql/resolvers/queries/group.ts
+++ b/ui/server/graphql/resolvers/queries/group.ts
@@ -43,7 +43,9 @@ export const groupInvitationLink = combineResolvers(
     return {
       link:
         group.inviteNonce !== null
-          ? appLink("/invite/" + sign({ nonce: group.inviteNonce, groupId }))
+          ? appLink(
+              "/invite/" + sign({ nonce: Number(group.inviteNonce), groupId })
+            )
           : null,
     };
   }

--- a/ui/server/graphql/resolvers/queries/round.ts
+++ b/ui/server/graphql/resolvers/queries/round.ts
@@ -159,7 +159,9 @@ export const invitationLink = async (parent, { roundId }, { user, ss }) => {
   return {
     link:
       round.inviteNonce !== null
-        ? appLink("/invite/" + sign({ nonce: round.inviteNonce, roundId }))
+        ? appLink(
+            "/invite/" + sign({ nonce: Number(round.inviteNonce), roundId })
+          )
         : null,
   };
 };

--- a/ui/server/graphql/schema/index.js
+++ b/ui/server/graphql/schema/index.js
@@ -501,7 +501,7 @@ const schema = gql`
     discourseCategoryId: Int
     tags: [Tag!]
     bucketStatusCount: BucketStatusCount
-    inviteNonce: Int
+    inviteNonce: BigInt
     updatedAt: Date
     distributedAmount: Int
     publishedBucketCount: Int

--- a/ui/server/prisma/migrations/20260729000000_fix_invite_nonce_bigint/migration.sql
+++ b/ui/server/prisma/migrations/20260729000000_fix_invite_nonce_bigint/migration.sql
@@ -1,0 +1,7 @@
+-- inviteNonce is generated with Date.now() -- a 13-digit millisecond timestamp
+-- (~1.78x10^12) that overflows a 4-byte INTEGER (max 2,147,483,647). Widen both
+-- invite-link columns to BIGINT. Same root cause already fixed on the
+-- give-it-a-go branch/DB for Collection only (20260531000000_fix_invite_nonce_bigint);
+-- this widens both tables on prod.
+ALTER TABLE "Collection" ALTER COLUMN "inviteNonce" TYPE BIGINT;
+ALTER TABLE "Organization" ALTER COLUMN "inviteNonce" TYPE BIGINT;

--- a/ui/server/prisma/schema.prisma
+++ b/ui/server/prisma/schema.prisma
@@ -178,7 +178,7 @@ model Group {
   groupMembers GroupMember[]
   rounds       Round[]
   discourse    DiscourseConfig?
-  inviteNonce  Int?
+  inviteNonce  BigInt?
 
   finishedTodos        Boolean @default(false)
   experimentalFeatures Boolean @default(false)
@@ -250,7 +250,7 @@ model Round {
   statusAccount   Account? @relation(fields: [statusAccountId], references: [id])
   statusAccountId String?  @unique
 
-  inviteNonce     Int?
+  inviteNonce     BigInt?
   maxMembers      Int?
   maxFreeBuckets  Int?
 


### PR DESCRIPTION
## Summary
- `cobudget.com` runs the `prod` branch/DB, separate from the give-it-a-go deployment. The inviteNonce BigInt overflow was already diagnosed and fixed there (commits `9d56d769`, `8ccb8a3d`, `58aa5c7a`), but that fix was never merged into `prod`.
- `Collection.inviteNonce` / `Organization.inviteNonce` have been plain `INTEGER` since a 2022 migration mistake. `Date.now()` (13-digit ms timestamp) overflows `INT4` deterministically on every invite-link creation.
- Confirmed on prod's real DB: both columns are currently `integer` (not previously patched).
- Mirrors the proven Round-path fix exactly (schema `BigInt?`, GraphQL schema `BigInt`, `String()` on mutation return, `Number()` before JWT `sign()`, `BigInt()` cast on join lookup), and extends the same pattern to the Group/Organization path (intentionally deferred on give-it-a-go since that instance doesn't use group invites, but prod does — this half is new, not previously battle-tested in prod).

## Test plan
- [x] `prisma generate` + `yarn typecheck` — no new errors introduced
- [x] `prisma migrate status` against prod DB — confirms only this one migration is pending
- [ ] Migration applied manually against prod DB (see below — should happen before/alongside this merging)
- [ ] Manual smoke test: create + join a round invite link
- [ ] Manual smoke test: create + join a group invite link (via GraphQL Playground, bypassing Stripe checkout)

## Migration
`ui/server/prisma/migrations/20260729000000_fix_invite_nonce_bigint/migration.sql` widens both `Collection.inviteNonce` and `Organization.inviteNonce` to `BIGINT`. This is being run manually against prod (CI's migration workflow isn't reliably applying), ideally before this PR merges so the DB and code land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)