### PR TITLE
Update contribution banner copy to donation-friendly wording

### DIFF
--- a/ui/components/UpgradeMessage.tsx
+++ b/ui/components/UpgradeMessage.tsx
@@ -81,8 +81,8 @@ export default function UpgradeMessage({
               </Typography>
               <Typography className="py-1" variant="body1">
                 <FormattedMessage
-                  defaultMessage="To keep Cobudget available, we depend on our users to financially contribute within their means. 
-  Please choose a contribution amount below to continue using Cobudget."
+                  defaultMessage="To keep Cobudget available, we depend on our users to financially contribute within their means.
+  Please choose an amount below to support this project."
                 />
               </Typography>
             </Box>
@@ -137,7 +137,7 @@ export default function UpgradeMessage({
                     <FormattedMessage defaultMessage="You’re managing multiple rounds for the same group of people, and want to group them under one payment." />
                   </li>
                   <li>
-                    <FormattedMessage defaultMessage="You have other questions about our self-set pricing model." />
+                    <FormattedMessage defaultMessage="You have other questions about our self set contribution model." />
                   </li>
                 </ul>
               </Typography>


### PR DESCRIPTION
## Summary
- Accountant confirmed contributions collected through Cobudget can be treated as donations, so the round member-limit banner (`UpgradeMessage.tsx`, admin view) drops "contribution amount"/"pricing" wording.
- "Please choose a contribution amount below to continue using Cobudget." → "Please choose an amount below to support this project."
- "You have other questions about our self-set pricing model." → "You have other questions about our self set contribution model."

No i18n keys touched — these strings aren't currently present in `en.json` or any locale file (extraction is already stale/out of sync with source, same as noted in #1279).

## Test plan
- [ ] Visit a round as admin where member count is at/near the round's member limit and confirm the updated copy renders correctly