### PR TITLE
Restore Create-a-Group subtitle with updated copy

### DIFF
--- a/ui/components/Group/NewGroup/index.tsx
+++ b/ui/components/Group/NewGroup/index.tsx
@@ -81,6 +81,9 @@ export default function NewGroup({ currentUser }) {
         <h1 className="text-4xl text-center font-bold mb-4">
           <FormattedMessage defaultMessage="Create a Group" />
         </h1>
+        <p className="text-center text-gray-600 text-xl mb-10">
+          <FormattedMessage defaultMessage="To continue using Cobudget" />
+        </p>
         <form
           action={`/api/stripe/create-checkout-session?mode=paidplan&priceId=${
             selectedPriceId ?? ""


### PR DESCRIPTION
## Summary
- The subtitle below the "Create a Group" header on `/new-group` was unintentionally dropped in the 2026-07-15 contribution-wording sweep (`5dce2c91`) — Fran had only asked for a reword, not removal.
- Restores the subtitle `<p>` in `ui/components/Group/NewGroup/index.tsx` with new copy: "To continue using Cobudget".

## Test plan
- [ ] Visit `/new-group` and confirm the grey subtitle appears below the header
- [ ] Confirm wording matches Fran's request